### PR TITLE
Ensure validation is performed on IDs

### DIFF
--- a/src/routes/production.ts
+++ b/src/routes/production.ts
@@ -19,10 +19,23 @@ export async function GetActive(req: Request, res: Response): Promise<void> {
 
 // get all shows corresponding to a production
 export async function GetShows(req: Request, res: Response): Promise<void> {
+  if (!/^\d+$/.test(req.params.id)) {
+    res.sendStatus(400);
+    return;
+  }
+
+  const id = parseInt(req.params.id, 10);
+
   try {
     const conn: Connection = await getConnection();
+    const prods = await conn.getRepository(Production).findOne({ id });
+    if (!prods) {
+      res.sendStatus(404);
+      return;
+    }
+
     const result = await conn.getRepository(Show).find({
-      production: { id: parseInt(req.params.id, 10) }
+      production: { id }
     });
     res.send(result);
   } catch (error) {

--- a/src/routes/show.ts
+++ b/src/routes/show.ts
@@ -6,6 +6,11 @@ import { Show } from "../entity/show";
 import Logger from "../logging";
 
 export async function GetShow(req: Request, res: Response) {
+  if (!/^\d+$/.test(req.params.id)) {
+    res.sendStatus(400);
+    return;
+  }
+
   try {
     const conn = getConnection();
     const show: Show = await conn.getRepository(Show).findOne(

--- a/tests/test.js
+++ b/tests/test.js
@@ -11,9 +11,11 @@ describe("productions", () => {
       server.get("/productions")
             .expect(200)
             .end( function (err, res) {
-              expect(res.status).to.equal(200);
-              for (const prop in ["id", "title", "subtitle", "year", "description", "shows"]) {
-                expect(res.body).to.have.property(prop);
+              expect(res.body).to.be.an('array').that.is.not.empty;
+              for (const production of res.body) {
+                for (const prop of ["id", "title", "subtitle", "year", "description", "location"]) {
+                  expect(production).to.have.property(prop);
+                }
               }
               done();
             });
@@ -24,9 +26,8 @@ describe("productions", () => {
       server.get("/productions/1/shows")
             .expect(200)
             .end( function (err, res) {
-              expect(res.status).to.equal(200);
-              for (const show in res.body) {
-                for (const prop in ["id", "location", "time", "production", "seats"]) {
+              for (const show of res.body) {
+                for (const prop of ["id", "time", "totalSeats", "reservedSeats"]) {
                   expect(show).to.have.property(prop);
                 }
               }
@@ -34,47 +35,31 @@ describe("productions", () => {
             });
     });
 
-  it ("retures a bad request for an invalid production id",
+  it ("get request for an non-existent production id",
     function (done) {
       server.get("/productions/999999/shows")
-            .expect(400)
-            .end( function (err, res) {
-              expect(res.status).to.equal(400);
-              done();
-            });
+            .expect(404, done);
     });
 
-  it ("retures a bad request for an invalid production id integer (negative)",
+  it ("returns a bad request for an invalid production id integer (negative)",
     function (done) {
       server.get("/productions/-999999/shows")
-            .expect(400)
-            .end( function (err, res) {
-              expect(res.status).to.equal(400);
-              done();
-            });
+            .expect(400, done);
     });
 
-  it ("retures a bad request for an invalid production id integer (floating point)",
+  it ("returns a bad request for an invalid production id integer (floating point)",
     function (done) {
       server.get("/productions/9999.99/shows")
-            .expect(400)
-            .end( function (err, res) {
-              expect(res.status).to.equal(400);
-              done();
-            });
+            .expect(400, done);
     });
 
-  it ("retures a bad request for an invalid production id integer (string)",
+  it ("returns a bad request for an invalid production id integer (string)",
     function (done) {
       server.get("/productions/undefined/shows")
-            .expect(400)
-            .end( function (err, res) {
-              expect(res.status).to.equal(400);
-              done();
-            });
+            .expect(400, done);
     });
 
-  it ("retures a bad request for an invalid production id integer (string with integer)",
+  it ("returns a bad request for an invalid production id integer (string with integer)",
     function (done) {
       server.get("/productions/undefined123/shows")
             .expect(400)
@@ -88,64 +73,43 @@ describe("productions", () => {
 describe("shows", () => {
   it ("gets the seat count for a valid show",
     function (done) {
-      server.get("/shows/1/seats")
+      server.get("/shows/1")
             .expect(200)
             .end( function (err, res) {
-              expect(res.status).to.equal(200);
-              for (const prop in ["id", "location", "time", "production", "seats"]) {
+              for (const prop of ["id", "time", "production", "totalSeats", "reservedSeats"]) {
                 expect(res.body).to.have.property(prop);
               }
               done();
             });
     });
 
-  it ("get bad request for an invalid show",
+  it ("get request for a non-existent show",
     function (done) {
-      server.get("/shows/99999/seats")
-            .expect(400)
-            .end( function (err, res) {
-              expect(res.status).to.equal(400);
-              done();
-            });
+      server.get("/shows/99999")
+            .expect(404, done);
     });
 
   it ("get bad request for an invalid show (negative)",
     function (done) {
-      server.get("/shows/-99999/seats")
-            .expect(400)
-            .end( function (err, res) {
-              expect(res.status).to.equal(400);
-              done();
-            });
+      server.get("/shows/-99999")
+            .expect(400, done);
     });
 
   it ("get bad request for an invalid show (floating point)",
     function (done) {
-      server.get("/shows/2134.324/seats")
-            .expect(400)
-            .end( function (err, res) {
-              expect(res.status).to.equal(400);
-              done();
-            });
+      server.get("/shows/2134.324")
+            .expect(400, done);
     });
 
   it ("get bad request for an invalid show (string)",
     function (done) {
-      server.get("/shows/undefined/seats")
-            .expect(400)
-            .end( function (err, res) {
-              expect(res.status).to.equal(400);
-              done();
-            });
+      server.get("/shows/undefined")
+            .expect(400, done);
     });
 
   it ("get bad request for an invalid show (string with number)",
     function (done) {
-      server.get("/shows/1234undefined/seats")
-            .expect(400)
-            .end( function (err, res) {
-              expect(res.status).to.equal(400);
-              done();
-            });
+      server.get("/shows/1234undefined")
+            .expect(400, done);
     });
 });


### PR DESCRIPTION
This ensures that the appropriate HTTP response code is returned if the
ID is invalid. Invalid IDs should return 400, while valid but
non-existent IDs return 404.

Also fixes the test cases to match new object keys and use for-of
instead of for-in.